### PR TITLE
Make OS agnostic

### DIFF
--- a/bin/reverse.js
+++ b/bin/reverse.js
@@ -175,7 +175,7 @@ fileList.forEach((filepath) => {
       if (fs.existsSync(outfile)) {
         console.error('File existed, skipping!');
       } else {
-        let dir = outfile.substr(0, outfile.lastIndexOf("\\"));
+        let dir = outfile.substr(0, outfile.lastIndexOf("/"));
         fs.ensureDirSync(dir);
         fs.writeFileSync(outfile, output[item], 'utf8');
       }

--- a/bin/reverse.js
+++ b/bin/reverse.js
@@ -175,7 +175,7 @@ fileList.forEach((filepath) => {
       if (fs.existsSync(outfile)) {
         console.error('File existed, skipping!');
       } else {
-        let dir = outfile.substr(0, outfile.lastIndexOf("/"));
+        let dir = path.dirname(outfile);
         fs.ensureDirSync(dir);
         fs.writeFileSync(outfile, output[item], 'utf8');
       }


### PR DESCRIPTION
`outfile.substr(0, outfile.lastIndexOf("\\"))` only works on Windows.
Using `path.dirname` will return the full path to the file on any operating system.